### PR TITLE
Use a table for the "Individual Friendship Progress"

### DIFF
--- a/index.html
+++ b/index.html
@@ -63,6 +63,7 @@ lets you know what is missing. Currently it checks for progress on 38 achievemen
 <noscript><span class="error">Javascript appears to be unsupported by or disabled in your browser. Stardew Checkup will not work without it.</span></noscript>
 <h2 id="sec_changelog">Changelog</h2>
 <ul>
+<li>unreleased - v2.6 - Changed friendship progress to a sortable table; PR from DerMitch</li>
 <li>15 Aug  2019 - v2.5.1 - Fixed duplicate Social output; PR from debashisbiswas</li>
 <li>22 June 2019 - v2.5   - Added Introductions quest summary to Social</li>
 <li>22 Feb  2019 - v2.4.1 - Fixed bug with detecting valid farmhands on MP saves</li>

--- a/stardew-checkup.css
+++ b/stardew-checkup.css
@@ -205,6 +205,9 @@ tr td:not(:first-child) {
 .SocialTable th {
 	text-align: left;
 }
+.SocialTable th.sortable {
+	cursor: pointer;
+}
 .SocialTable th, .SocialTable td {
 	border-left: 1px solid #555;
 	border-bottom: 1px solid #555;

--- a/stardew-checkup.css
+++ b/stardew-checkup.css
@@ -197,3 +197,19 @@ tr td:not(:first-child) {
 #TOC li a:hover {
 	background-color: #ffe0b0;
 }
+
+.SocialTable {
+	border: 1px solid #555;
+	border-left: 0;
+}
+.SocialTable th {
+	text-align: left;
+}
+.SocialTable th, .SocialTable td {
+	border-left: 1px solid #555;
+	border-bottom: 1px solid #555;
+	padding: 2px 10px;
+}
+.SocialTable td.text-right {
+	text-align: right;
+}

--- a/stardew-checkup.js
+++ b/stardew-checkup.js
@@ -412,13 +412,13 @@ window.onload = function () {
 					if (arr[1] === 3910979) {
 						extra = " (Jas &amp; Vincent both)";
 					}
-					eventInfo += ' <span class="ms_' + (seen ? 'yes':neg) + '">' + id + '&#x2665;' + extra + '</span>';
+					eventInfo += ' <span class="ms_' + (seen ? 'yes':neg) + '">' + id + '&#x2665;' + extra + '</span>&nbsp;&nbsp;';
 				}
 			} else {
 				if (arr[1] === 639373) {
 					extra = " (Lewis &amp; Marnie both)";
 				}
-				eventInfo += ' <span class="ms_' + (seen ? 'yes':neg) + '">' + arr[0] + '&#x2665;' + extra + '</span>';
+				eventInfo += ' <span class="ms_' + (seen ? 'yes':neg) + '">' + arr[0] + '&#x2665;' + extra + '</span>&nbsp;&nbsp;';
 			}
 		};
 		for (var who in npc) {

--- a/stardew-checkup.js
+++ b/stardew-checkup.js
@@ -562,13 +562,14 @@ window.onload = function () {
 	 * - All potential bachelors
 	 * - All other villagers
 	 *
-	 * Each category is a list with objects of the following fields:
-	 * - name (String)
-	 * - status (String)
-	 * - hearts (Number)
-	 * - points (Number)
-	 * - points_needed (String)
-	 * - events (HTML)
+	 * Each category is a list with objects of the following fields,
+	 * each is a string containing HTML.
+	 * - name
+	 * - status
+	 * - hearts
+	 * - points
+	 * - points_needed
+	 * - events
 	 */
 	function renderSocialTable(family, bachelors, other) {
 		var output = [];


### PR DESCRIPTION
Stardew Checkup has been a great tool for checking and improving my game progress.

Yet, one issue for me has always been the readability of the friendship progress list, which I currently use a lot currently to finish some achievements.

This pull request changes the current nested list to a table, which can also be sorted.

Screenshot of the new look:
![Bildschirmfoto 2019-10-29 um 20 38 12](https://user-images.githubusercontent.com/178672/67802747-10755080-fa8c-11e9-9291-ba00f0de463c.png)
