### PR TITLE
Fixed accounting for players not having individualMoneyEarned

### DIFF
--- a/stardew-checkup.js
+++ b/stardew-checkup.js
@@ -1107,7 +1107,7 @@ window.onload = function () {
 			output += '<div class="' + meta.anchor + '_details ' + meta.det_class + '">';
 			output += '<span class="result">Earnings Breakdown:</span><ul class="outer">';
 			Object.keys(saveInfo.players).forEach(function(id) {
-				var m = saveInfo.data[id].stats.individualMoneyEarned;
+				var m = saveInfo.data[id].stats.individualMoneyEarned || 0;
 				output += '<li>' + addCommas(m) + 'g earned by ' + saveInfo.players[id] + '</li>';
 				left -= m;
 			});


### PR DESCRIPTION
Players who have not played since 1.6 don't have `individualMoneyEarned` and the program has an error:

```
parseMoney, line 1111 - Uncaught TypeError: can't access property "toString", x is undefined.
```

 This accounts for that and defaults to 0.